### PR TITLE
remove scanning timeout handler successfully connected or disconnected

### DIFF
--- a/app/src/main/java/com/samourai/txtenna/utils/goTennaUtil.java
+++ b/app/src/main/java/com/samourai/txtenna/utils/goTennaUtil.java
@@ -169,6 +169,7 @@ public class goTennaUtil implements GTConnectionListener {
         }
         if (gtConnectionState != GTConnectionState.SCANNING) {
             getGtConnectionManager().removeGtConnectionListener(this);
+            handler.removeCallbacks(scanTimeoutRunnable);
             callbackActivity = null;
         }
     }


### PR DESCRIPTION
Currently callbackActivity is set to null which prevents a problem, but there is still a potential race condition.